### PR TITLE
chore: promote go-demo to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/go-demo/go-demo-go-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/go-demo/go-demo-go-demo-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: go-demo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-demo-go-demo
+  labels:
+    draft: draft-app
+    chart: "go-demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: go-demo-go-demo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: go-demo-go-demo
+    spec:
+      serviceAccountName: go-demo-go-demo
+      containers:
+        - name: go-demo
+          image: "gcr.io/vm-test-jx/go-demo:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/go-demo/go-demo-go-demo-sa.yaml
+++ b/config-root/namespaces/jx-staging/go-demo/go-demo-go-demo-sa.yaml
@@ -1,0 +1,8 @@
+# Source: go-demo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: go-demo-go-demo
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/go-demo/go-demo-ingress.yaml
+++ b/config-root/namespaces/jx-staging/go-demo/go-demo-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: go-demo/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: go-demo
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: go-demo
+              servicePort: 80
+      host: go-demo-jx-staging.35.232.140.43.nip.io

--- a/config-root/namespaces/jx-staging/go-demo/go-demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/go-demo/go-demo-svc.yaml
@@ -1,0 +1,18 @@
+# Source: go-demo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-demo
+  labels:
+    chart: "go-demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: go-demo-go-demo

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,12 @@
 	      <td><a href='https://github.com/jenkins-x/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> go-demo </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://go-demo-jx-staging.35.232.140.43.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -47,6 +47,19 @@
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx-staging/jx-verify
+  - apiVersion: v1
+    applicationUrl: http://go-demo-jx-staging.35.232.140.43.nip.io
+    description: A Helm chart for Kubernetes
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: go-demo
+      url: http://go-demo-jx-staging.35.232.140.43.nip.io
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=vm-test-jx&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-fluent-fish%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fgo-demo&dateRangeUnbound=both
+    name: go-demo
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.232.140.43.nip.io/
+    resourcePath: config-root/namespaces/jx-staging/go-demo
+    version: 0.0.1
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: go-demo
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jx3
   url: https://storage.googleapis.com/jenkinsxio/charts
+- name: dev
+  url: http://chartmuseum-jx.35.232.140.43.nip.io/
 releases:
 - chart: jx3/jx-verify
   name: jx-verify
   namespace: jx-staging
   values:
   - jx-values.yaml
+- chart: dev/go-demo
+  version: 0.0.1
+  name: go-demo
+  namespace: jx-staging
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote go-demo to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
