### PR TITLE
chore: promote go-demo to version 0.0.1

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jx3
   url: https://storage.googleapis.com/jenkinsxio/charts
+- name: dev
+  url: http://chartmuseum-jx.35.232.140.43.nip.io/
 releases:
 - chart: jx3/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/go-demo
+  version: 0.0.1
+  name: go-demo
+  namespace: jx-production
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote go-demo to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
